### PR TITLE
Added more testing configuration options 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "ts-mocha -p tsconfig.json --require ignore-styles src/**/*_test.{ts,tsx}",
+    "test:single": "mocha --require ts-node/register 'src/**/*_test.tsx' -g",
+    "test:describe": "mocha --require ts-node/register 'src/**/*_test.tsx' -g",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Added the option to test:
- Single individual tests.
- Groups of tests under `describe` sections.
... within the terminal.

Example commands:
- This runs the single test named "should verity that 0 equals 0".
    `npm run test:single -- "should verify that 0 equals 0"`

- This runs all tests under the describe block named "Rendering".
    `npm run test:describe -- "Rendering" `
